### PR TITLE
Forward build arguments

### DIFF
--- a/.github/workflows/fog_ros_baseimage_update_dispatch.yaml
+++ b/.github/workflows/fog_ros_baseimage_update_dispatch.yaml
@@ -9,12 +9,9 @@ jobs:
     strategy:
       matrix:
         repo: [
-          'tiiuae/control_interface',
           'tiiuae/depthai_ctrl',
-          'tiiuae/fog_bumper',
           'tiiuae/mavlink-router',
           'tiiuae/mocap_pose',
-          'tiiuae/navigation',
           'tiiuae/octomap_server2',
           'tiiuae/px4_ros_com',
           'tiiuae/rplidar_ros2'

--- a/builder/packaging/build.sh
+++ b/builder/packaging/build.sh
@@ -7,6 +7,49 @@
 
 # (fakeroot wraps debian/rules invocation seeming like it's run as root)
 
+usage() {
+	echo "
+Usage: $(basename "$0") [-h] [-b nbr]
+Params:
+    -h  Show help text.
+    -b  Build number. This will be tha last digit of version string (x.x.N).
+"
+	exit 0
+}
+
+check_arg() {
+	if [ "$(echo $1 | cut -c1)" = "-" ]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+error_arg() {
+	echo "$0: option requires an argument -- $1"
+	usage
+}
+
+# this should refer to the repo's root dir.
+# this used some clever tricks before, but now using just assumption that this is invoked from repo root.
+mod_dir="$(pwd)"
+build_number=0
+
+while getopts "hb:" opt
+do
+	case $opt in
+		h)
+			usage
+			;;
+		b)
+			check_arg $OPTARG && build_number=$OPTARG || error_arg $opt
+			;;
+		\?)
+			usage
+			;;
+	esac
+done
+
 function rosdep_init_update_and_install {
 	local mod_dir="$1" # probably /main_ws/src
 
@@ -142,5 +185,5 @@ function build_process {
 
 # not being sourced?
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	build_process "$@"
+	build_process -b ${build_number}
 fi

--- a/builder/packaging/build.sh
+++ b/builder/packaging/build.sh
@@ -133,14 +133,14 @@ function build_process {
 	# so temporarily change to that dir for package.sh to work
 	if [[ ! -e package.xml ]]; then
 		pushd $(dirname $(find -name package.xml))
-		/packaging/package.sh
+		/packaging/package.sh "$@"
 		popd
 	else
-		/packaging/package.sh
+		/packaging/package.sh "$@"
 	fi
 }
 
 # not being sourced?
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	build_process
+	build_process "$@"
 fi

--- a/builder/packaging/package.sh
+++ b/builder/packaging/package.sh
@@ -12,7 +12,7 @@ Params:
     -d  Distribution string in debian changelog.
     -g  Git commit hash.
     -v  Git version string
-    -v  Output dir
+    -o  Output dir
 "
 	exit 0
 }

--- a/builder/packaging/rosdep.yaml
+++ b/builder/packaging/rosdep.yaml
@@ -10,15 +10,15 @@
 dynamicEDT3D:
     ubuntu: ros-galactic-dynamic-edt-3d
 fastcdr:
-    ubuntu: ros-galactic-fastcdr=1.0.20*
+    ubuntu: ros-galactic-fastcdr=1.0.23*
 fastrtps:
-    ubuntu: ros-galactic-fastrtps=2.5.0*
+    ubuntu: ros-galactic-fastrtps=2.5.1*
 fastrtps_cmake_module:
     ubuntu: ros-galactic-fastrtps-cmake-module=1.2.1*
 fog_msgs:
     ubuntu: ros-galactic-fog-msgs=0.0.8*
 foonathan_memory_vendor:
-    ubuntu: ros-galactic-foonathan-memory-vendor=1.1.0*
+    ubuntu: ros-galactic-foonathan-memory-vendor=1.2.1*
 px4_msgs:
     ubuntu: ros-galactic-px4-msgs=3.0.0*
 rosidl_default_generators:


### PR DESCRIPTION
Needed for fog_msgs and px4_msgs package building which needs to use build number.