### PR TITLE
Dp 4266 Humble Upgrade

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,11 +39,12 @@ jobs:
         id: meta_builder # referenced from later step
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/tiiuae/fog-ros-baseimage
+          images: ghcr.io/tiiuae/fog-ros-baseimage-builder
           tags: |
-            type=ref,event=branch,prefix=builder-
-            type=raw,value=builder-latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-            type=sha,prefix=builder-
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
 
       - name: Build and push base image
         uses: docker/build-push-action@v2

--- a/DEFAULT_FASTRTPS_PROFILES.xml
+++ b/DEFAULT_FASTRTPS_PROFILES.xml
@@ -20,13 +20,13 @@
                 <discovery_config>
                     <leaseDuration>
                         <!-- DURATION -->
-                        <sec>20</sec>
+                        <sec>50</sec>
                         <nanosec>0</nanosec>
                     </leaseDuration>
 
                     <leaseAnnouncement>
                         <!-- DURATION -->
-                        <sec>10</sec>
+                        <sec>6</sec>
                         <nanosec>0</nanosec>
                     </leaseAnnouncement>
                 </discovery_config>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROS_DISTRO=galactic
+ARG ROS_DISTRO=humble
 
 FROM ros:${ROS_DISTRO}-ros-core
 
@@ -14,7 +14,7 @@ ENV FASTRTPS_DEFAULT_PROFILES_FILE=/etc/DEFAULT_FASTRTPS_PROFILES.xml
 
 # so we can download our own-produced components
 # Packages with PKCS#11 features have fog-sw-sros component.
-RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-debian-public-remote" \
+RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
 	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw" > /etc/apt/sources.list.d/fogsw.list \
 	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list \
 	&& apt update
@@ -29,29 +29,30 @@ RUN apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature
-	ros-${ROS_DISTRO}-fastcdr=1.0.23-34~git20220620.92bc6c3 \
-	ros-${ROS_DISTRO}-fastrtps=2.5.1-34~git20221127.d398c9e \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=1.2.1-34~git20220815.16ec09c \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.1-34~git20220620.69df181 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=5.0.0-34~git20221127.c2deeb1 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=5.0.0-34~git20221127.c2deeb1 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=5.0.0-34~git20221127.c2deeb1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=1.2.1-34~git20220815.16ec09c \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=1.2.1-34~git20220815.16ec09c \
-	ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
-	ros-${ROS_DISTRO}-px4-msgs=4.0.0-31~git20220804.5058022 \
-	ros-${ROS_DISTRO}-fognav-msgs=0.1.0-33~git20221007.a0451ca
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-18~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.9.0-18~git20221213.4c55488 \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-18~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-18~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-18~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-18~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-18~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-18~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-18~git20220330.89b19c1 \
+	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
+	# ros-${ROS_DISTRO}-px4-msgs=4.0.0-31~git20220804.5058022 \ # FIXME: ADD AFTER UPDATE
+	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d
 
 # wrapper used to launch ros with proper environment variables
 COPY ros-with-env.sh /usr/bin/ros-with-env
 
+# FIXME: ENABLE AFTER pkcs11-proxy1 IS AVAILABLE IN OUR REPO
 # Install pkcs11-proxy client library
-RUN apt-get update && \
-	apt-get install -y --no-install-recommends \
-        libengine-pkcs11-openssl \
-        libp11-dev \
-        pkcs11-proxy1 && \
-	rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && \
+# 	apt-get install -y --no-install-recommends \
+#         libengine-pkcs11-openssl \
+#         libp11-dev \
+#         pkcs11-proxy1 && \
+# 	rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ENV FASTRTPS_DEFAULT_PROFILES_FILE=/etc/DEFAULT_FASTRTPS_PROFILES.xml
 # Packages with PKCS#11 features have fog-sw-sros component.
 RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
 	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw" > /etc/apt/sources.list.d/fogsw.list \
-	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list \
-	&& apt update
+	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list
 
 # fog-health is used by concrete applications as a container HEALTHCHECK to derive health status from
 # Prometheus metrics. currently installing from S3 bucket because I failed to setup download from private repo's releases.
@@ -29,22 +28,23 @@ ADD https://s3.amazonaws.com/files.function61.com/random-drops/2023/fog-health_l
 # FastRTPS pinned because our SSRC repo had newer version which was incompatible with our current applications.
 # WARNING: the same pinning happens in Dockerfile.builder, please update that if you change this!
 # TODO: remove pinning once it's no longer required
-RUN chmod +x /usr/bin/fog-health && apt install -y \
+RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-18~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.9.0-18~git20221213.4c55488 \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-18~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-18~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-18~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-18~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-18~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-18~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-18~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-38~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.9.0-38~git20230110.df2857a \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-38~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-38~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=4.0.0-40~git20230102.9000489 \
-	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d
+	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \
+	&& rm -rf /var/lib/apt/lists/*
 
 # wrapper used to launch ros with proper environment variables
 COPY ros-with-env.sh /usr/bin/ros-with-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,15 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-38~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.9.0-38~git20230110.df2857a \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-38~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-38~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-38~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-40~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.9.0-40~git20230110.df2857a \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-40~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-40~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=4.0.0-40~git20230102.9000489 \
 	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,15 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-43~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.10.0-43~git20230127.6a68664 \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-43~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-43~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-43~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-44~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.10.0-44~git20230127.6a68664 \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-44~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-44~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-44~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-44~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=5.0.0-41~git20230130.b2a125f \
 	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-44~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=5.0.0-41~git20230130.b2a125f \
-	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \
+	ros-${ROS_DISTRO}-fognav-msgs=1.1.0-8~git20230203.f7349f8 \
 	&& rm -rf /var/lib/apt/lists/*
 
 # wrapper used to launch ros with proper environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,17 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-40~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.9.0-40~git20230110.df2857a \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-40~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-40~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-40~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-43~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.10.0-43~git20230127.6a68664 \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-43~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-43~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
-	ros-${ROS_DISTRO}-px4-msgs=4.0.0-40~git20230102.9000489 \
+	ros-${ROS_DISTRO}-px4-msgs=5.0.0-41~git20230130.b2a125f \
 	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,17 @@ RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
 	&& echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list \
 	&& apt update
 
+# fog-health is used by concrete applications as a container HEALTHCHECK to derive health status from
+# Prometheus metrics. currently installing from S3 bucket because I failed to setup download from private repo's releases.
+ADD https://s3.amazonaws.com/files.function61.com/random-drops/2023/fog-health_linux-amd64 /usr/bin/fog-health
+
 # be careful about introducing dependencies here that already come from ros-core, because adding
 # them again here means updating them to latest version, which might not be what we want?
 #
 # FastRTPS pinned because our SSRC repo had newer version which was incompatible with our current applications.
 # WARNING: the same pinning happens in Dockerfile.builder, please update that if you change this!
 # TODO: remove pinning once it's no longer required
-RUN apt install -y \
+RUN chmod +x /usr/bin/fog-health && apt install -y \
 	ros-${ROS_DISTRO}-geodesy \
 	ros-${ROS_DISTRO}-tf2-ros \
 	# Packages with PKCS#11 feature

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=5.0.0-41~git20230130.b2a125f \
 	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d \
-  && chmod +x /usr/bin/fog-health \
 	&& rm -rf /var/lib/apt/lists/*
 
 # wrapper used to launch ros with proper environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN chmod +x /usr/bin/fog-health && apt update && apt install -y \
 	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-44~git20221108.8932659 \
 	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-44~git20220330.89b19c1 \
 	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-44~git20220330.89b19c1 \
-	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
 	ros-${ROS_DISTRO}-px4-msgs=5.0.0-41~git20230130.b2a125f \
 	ros-${ROS_DISTRO}-fognav-msgs=1.1.0-8~git20230203.f7349f8 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,20 +39,19 @@ RUN apt install -y \
 	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-18~git20220330.89b19c1 \
 	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-18~git20220330.89b19c1 \
 	# ros-${ROS_DISTRO}-fog-msgs=0.0.8-42~git20220104.1d2cf3f \
-	# ros-${ROS_DISTRO}-px4-msgs=4.0.0-31~git20220804.5058022 \ # FIXME: ADD AFTER UPDATE
+	ros-${ROS_DISTRO}-px4-msgs=4.0.0-40~git20230102.9000489 \
 	ros-${ROS_DISTRO}-fognav-msgs=1.0.0-3~git20221229.664b19d
 
 # wrapper used to launch ros with proper environment variables
 COPY ros-with-env.sh /usr/bin/ros-with-env
 
-# FIXME: ENABLE AFTER pkcs11-proxy1 IS AVAILABLE IN OUR REPO
 # Install pkcs11-proxy client library
-# RUN apt-get update && \
-# 	apt-get install -y --no-install-recommends \
-#         libengine-pkcs11-openssl \
-#         libp11-dev \
-#         pkcs11-proxy1 && \
-# 	rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+        libengine-pkcs11-openssl \
+        libp11-dev \
+        pkcs11-proxy1 && \
+	rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -34,15 +34,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-bloom \
     dh-make \
     libboost-dev \
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-38~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.9.0-38~git20230110.df2857a \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-38~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-38~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-38~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-38~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-40~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.9.0-40~git20230110.df2857a \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-40~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-40~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-40~git20220330.89b19c1 \
     && rm -rf /var/lib/apt/lists/*
 
 # dedicated user because ROS builds can complain if building as root.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -34,15 +34,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-bloom \
     dh-make \
     libboost-dev \
-    ros-${ROS_DISTRO}-fastcdr=1.0.26-18~git20221212.6184f25 \
-    ros-${ROS_DISTRO}-fastrtps=2.9.0-18~git20221213.4c55488 \
-    ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-18~git20220330.89b19c1 \
-    ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-18~git20221212.2ef9fc0 \
-    ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-18~git20221108.8932659 \
-    ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-18~git20221108.8932659 \
-    ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-18~git20221108.8932659 \
-    ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-18~git20220330.89b19c1 \
-    ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-18~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-38~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.9.0-38~git20230110.df2857a \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-38~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-38~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-38~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-38~git20220330.89b19c1 \
     && rm -rf /var/lib/apt/lists/*
 
 # dedicated user because ROS builds can complain if building as root.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -34,15 +34,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-bloom \
     dh-make \
     libboost-dev \
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-40~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.9.0-40~git20230110.df2857a \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-40~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-40~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-40~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-40~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-40~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-43~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.10.0-43~git20230127.6a68664 \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-43~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-43~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-43~git20220330.89b19c1 \
     && rm -rf /var/lib/apt/lists/*
 
 # dedicated user because ROS builds can complain if building as root.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -34,15 +34,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-bloom \
     dh-make \
     libboost-dev \
-	ros-${ROS_DISTRO}-fastcdr=1.0.26-43~git20221212.6184f25 \
-	ros-${ROS_DISTRO}-fastrtps=2.10.0-43~git20230127.6a68664 \
-	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-43~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-43~git20221212.2ef9fc0 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-43~git20221108.8932659 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-43~git20220330.89b19c1 \
-	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-43~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-fastcdr=1.0.26-44~git20221212.6184f25 \
+	ros-${ROS_DISTRO}-fastrtps=2.10.0-44~git20230127.6a68664 \
+	ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-44~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-44~git20221212.2ef9fc0 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-44~git20221108.8932659 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-44~git20220330.89b19c1 \
+	ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-44~git20220330.89b19c1 \
     && rm -rf /var/lib/apt/lists/*
 
 # dedicated user because ROS builds can complain if building as root.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -23,7 +23,7 @@ RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
     && echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list
 
 # Install build dependencies
-# - ros-<DISTRO>-rmw-fastrtps-cpp is needed for building msgs (fog-msgs, px4-msgs)
+# - ros-<DISTRO>-rmw-fastrtps-cpp is needed for building msgs (fognav-msgs, px4-msgs)
 # - prometheus-cpp is needed for build headers
 #
 # WARNING: the same FastRTPS pinning happens in Dockerfile, please update that if you change this!

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -5,7 +5,7 @@
 
 # please don't use this as dynamic build argument from outside of this file.
 # this is more of a shared constant-like type situation in this file.
-ARG ROS_DISTRO="galactic"
+ARG ROS_DISTRO="humble"
 
 FROM ros:${ROS_DISTRO}-ros-base
 
@@ -18,7 +18,7 @@ ARG GID=1001
 # needs to be done before FastRTPS installation because we seem to have have newer version of that
 # package in our repo. also fast-dds-gen seems to only be available from this repo.
 # Packages with PKCS#11 features have fog-sw-sros component.
-RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-debian-public-remote" \
+RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
     && echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw" > /etc/apt/sources.list.d/fogsw.list \
     && echo "deb [trusted=yes] ${FOG_DEB_REPO} $(lsb_release -cs) fog-sw-sros" >> /etc/apt/sources.list.d/fogsw-sros.list
 
@@ -32,8 +32,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
     python3-bloom \
     dh-make \
     libboost-dev \
-    ros-${ROS_DISTRO}-fastrtps=2.5.1-34~git20221127.d398c9e \
-    ros-${ROS_DISTRO}-rmw-fastrtps-cpp=5.0.0-34~git20221127.c2deeb1 \
+    ros-${ROS_DISTRO}-fastcdr=1.0.26-18~git20221212.6184f25 \
+    ros-${ROS_DISTRO}-fastrtps=2.9.0-18~git20221213.4c55488 \
+    ros-${ROS_DISTRO}-fastrtps-cmake-module=2.2.0-18~git20220330.89b19c1 \
+    ros-${ROS_DISTRO}-foonathan-memory-vendor=1.2.2-18~git20221212.2ef9fc0 \
+    ros-${ROS_DISTRO}-rmw-fastrtps-cpp=6.2.2-18~git20221108.8932659 \
+    ros-${ROS_DISTRO}-rmw-fastrtps-dynamic-cpp=6.2.2-18~git20221108.8932659 \
+    ros-${ROS_DISTRO}-rmw-fastrtps-shared-cpp=6.2.2-18~git20221108.8932659 \
+    ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-c=2.2.0-18~git20220330.89b19c1 \
+    ros-${ROS_DISTRO}-rosidl-typesupport-fastrtps-cpp=2.2.0-18~git20220330.89b19c1 \
     && rm -rf /var/lib/apt/lists/*
 
 # dedicated user because ROS builds can complain if building as root.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -24,11 +24,13 @@ RUN FOG_DEB_REPO="https://ssrc.jfrog.io/artifactory/ssrc-deb-public-local" \
 
 # Install build dependencies
 # - ros-<DISTRO>-rmw-fastrtps-cpp is needed for building msgs (fog-msgs, px4-msgs)
+# - prometheus-cpp is needed for build headers
 #
 # WARNING: the same FastRTPS pinning happens in Dockerfile, please update that if you change this!
 #   (see the other file for rationale. we need pinning in builder also due to micrortps-agent linking directly to fastrtps)
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
     curl \
+    prometheus-cpp \
     python3-bloom \
     dh-make \
     libboost-dev \

--- a/builder/packaging/build-and-package-as-deb.sh
+++ b/builder/packaging/build-and-package-as-deb.sh
@@ -120,10 +120,10 @@ if [ -e ${mod_dir}/debian ]; then
 	cp -r debian debian_bak
 fi
 
-bloom-generate rosdebian --os-name ubuntu --os-version focal --ros-distro ${ROS_DISTRO} --place-template-files \
+bloom-generate rosdebian --os-name ubuntu --os-version jammy --ros-distro ${ROS_DISTRO} --place-template-files \
     && sed -i "s/@(DebianInc)@(Distribution)/@(DebianInc)/" debian/changelog.em \
     && [ ! "$distr" = "" ] && sed -i "s/@(Distribution)/${distr}/" debian/changelog.em || : \
-    && bloom-generate rosdebian --os-name ubuntu --os-version focal --ros-distro ${ROS_DISTRO} --process-template-files -i ${build_nbr}${git_version_string} \
+    && bloom-generate rosdebian --os-name ubuntu --os-version jammy --ros-distro ${ROS_DISTRO} --process-template-files -i ${build_nbr}${git_version_string} \
     && sed -i 's/^\tdh_shlibdeps.*/& --dpkg-shlibdeps-params=--ignore-missing-info/g' debian/rules \
 		&& sed -i "s/\=\([0-9]*\.[0-9]*\.[0-9]*\*\)//g" debian/control \
     && fakeroot debian/rules clean \

--- a/builder/packaging/build.sh
+++ b/builder/packaging/build.sh
@@ -74,7 +74,7 @@ function rosdep_init_update_and_install {
 	fi
 
 	echo "[INFO] Updating rosdep"
-	rosdep update --include-eol-distros
+	rosdep update
 
 	apt update
 	echo "[INFO] Running rosdep install.."
@@ -166,7 +166,7 @@ function step {
 function build_process {
 	step rosdep_init_update_and_install /main_ws/src
 
-	rosdep update --include-eol-distros
+	rosdep update
 
 	if [[ ! -v SKIP_BUILD_UNDERLAY_STEPS ]]; then
 		step build_underlay_deps /main_ws/src

--- a/builder/packaging/package.sh
+++ b/builder/packaging/package.sh
@@ -110,14 +110,14 @@ fi
 export DEB_BUILD_OPTIONS="parallel=`nproc`"
 
 # generates makefile at debian/rules, which is used to invoke the actual build.
-bloom-generate rosdebian --os-name ubuntu --os-version focal --ros-distro ${ROS_DISTRO} --place-template-files
+bloom-generate rosdebian --os-name ubuntu --os-version jammy --ros-distro ${ROS_DISTRO} --place-template-files
 
 sed -i "s/@(DebianInc)@(Distribution)/@(DebianInc)/" debian/changelog.em
 
 # modify the distribution in the template and ignore warnings from sed and not stop the script.
 [ ! "$distr" = "" ] && sed -i "s/@(Distribution)/${distr}/" debian/changelog.em || :
 
-bloom-generate rosdebian --os-name ubuntu --os-version focal --ros-distro ${ROS_DISTRO} --process-template-files -i ${build_nbr}${git_version_string}
+bloom-generate rosdebian --os-name ubuntu --os-version jammy --ros-distro ${ROS_DISTRO} --process-template-files -i ${build_nbr}${git_version_string}
 
 sed -i 's/^\tdh_shlibdeps.*/& --dpkg-shlibdeps-params=--ignore-missing-info/g' debian/rules
 

--- a/builder/packaging/rosdep.yaml
+++ b/builder/packaging/rosdep.yaml
@@ -12,7 +12,7 @@ dynamicEDT3D:
 fastcdr:
     ubuntu: ros-humble-fastcdr=1.0.26*
 fastrtps:
-    ubuntu: ros-humble-fastrtps=2.9.0*
+    ubuntu: ros-humble-fastrtps=2.10.0*
 fastrtps_cmake_module:
     ubuntu: ros-humble-fastrtps-cmake-module=2.2.0*
 fog_msgs:
@@ -20,7 +20,7 @@ fog_msgs:
 foonathan_memory_vendor:
     ubuntu: ros-humble-foonathan-memory-vendor=1.2.2*
 px4_msgs:
-    ubuntu: ros-humble-px4-msgs=4.0.0*
+    ubuntu: ros-humble-px4-msgs=5.0.0*
 fognav_msgs:
     ubuntu: ros-humble-fognav-msgs=1.0.0*
 rosidl_default_generators:

--- a/builder/packaging/rosdep.yaml
+++ b/builder/packaging/rosdep.yaml
@@ -4,30 +4,30 @@
 # This is a translation layer from "ROS package" name into the package name used by your distro's
 # package manager (package name can be different in apt/yum/pip repos..).
 #
-# e.g. "px4_msgs in Debian packages means ros-galactic-px4-msgs"
+# e.g. "px4_msgs in Debian packages means ros-humble-px4-msgs"
 # see: https://wiki.ros.org/rosdep/rosdep.yaml
 
 dynamicEDT3D:
-    ubuntu: ros-galactic-dynamic-edt-3d
+    ubuntu: ros-humble-dynamic-edt-3d
 fastcdr:
-    ubuntu: ros-galactic-fastcdr=1.0.23*
+    ubuntu: ros-humble-fastcdr=1.0.26*
 fastrtps:
-    ubuntu: ros-galactic-fastrtps=2.5.1*
+    ubuntu: ros-humble-fastrtps=2.9.0*
 fastrtps_cmake_module:
-    ubuntu: ros-galactic-fastrtps-cmake-module=1.2.1*
+    ubuntu: ros-humble-fastrtps-cmake-module=2.2.0*
 fog_msgs:
-    ubuntu: ros-galactic-fog-msgs=0.0.8*
+    ubuntu: ros-humble-fog-msgs=0.0.8*
 foonathan_memory_vendor:
-    ubuntu: ros-galactic-foonathan-memory-vendor=1.2.1*
+    ubuntu: ros-humble-foonathan-memory-vendor=1.2.2*
 px4_msgs:
-    ubuntu: ros-galactic-px4-msgs=4.0.0*
+    ubuntu: ros-humble-px4-msgs=4.0.0*
 fognav_msgs:
-    ubuntu: ros-galactic-fognav-msgs=0.1.0*
+    ubuntu: ros-humble-fognav-msgs=1.0.0*
 rosidl_default_generators:
-    ubuntu: ros-galactic-rosidl-default-generators
+    ubuntu: ros-humble-rosidl-default-generators
 rosidl_typesupport_fastrtps_c:
-    ubuntu: ros-galactic-rosidl-typesupport-fastrtps-c=1.2.1*
+    ubuntu: ros-humble-rosidl-typesupport-fastrtps-c=2.2.0*
 rosidl_typesupport_fastrtps_cpp:
-    ubuntu: ros-galactic-rosidl-typesupport-fastrtps-cpp=1.2.1*
+    ubuntu: ros-humble-rosidl-typesupport-fastrtps-cpp=2.2.0*
 mavsdk:
     ubuntu: mavsdk=0.42.0*

--- a/builder/packaging/rosdep.yaml
+++ b/builder/packaging/rosdep.yaml
@@ -22,7 +22,7 @@ foonathan_memory_vendor:
 px4_msgs:
     ubuntu: ros-humble-px4-msgs=5.0.0*
 fognav_msgs:
-    ubuntu: ros-humble-fognav-msgs=1.0.0*
+    ubuntu: ros-humble-fognav-msgs=1.1.0*
 rosidl_default_generators:
     ubuntu: ros-humble-rosidl-default-generators
 rosidl_typesupport_fastrtps_c:

--- a/builder/packaging/rosdep.yaml
+++ b/builder/packaging/rosdep.yaml
@@ -15,8 +15,6 @@ fastrtps:
     ubuntu: ros-humble-fastrtps=2.10.0*
 fastrtps_cmake_module:
     ubuntu: ros-humble-fastrtps-cmake-module=2.2.0*
-fog_msgs:
-    ubuntu: ros-humble-fog-msgs=0.0.8*
 foonathan_memory_vendor:
     ubuntu: ros-humble-foonathan-memory-vendor=1.2.2*
 px4_msgs:


### PR DESCRIPTION
## Changelog;
- ROS2 version upgraded from Galactic to **Humble**
- `Fast-DDS` upgraded to `2.10.0`
- `rmw_fastrtps` upgraded to `6.2.2`
- Fog health binary and prometheus added
- Increased FastDDS profiles lease duration and decreased lease announcement.
- Default artifactory repo in the baseimage now is to `ssrc-deb-public-local` instead of remote one.